### PR TITLE
Adding ability to specify self-hosted GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 Hello,
 
-If you want to integrate the OX scanner into your Github action pipelines, you can use the Python program mentioned above.
+If you want to integrate the OX scanner into your GitHub Action pipelines, you can use this Python program.
 
-Just modify the following parameters:
+Modify the following parameters:
 
-1. ACCESS_TOKEN - insert your token to add the pipeline scanner YAML file.
-2. ox_host_url - insert your on-prem server URL.
+1. ACCESS_TOKEN - insert your GitHub token to allow the pipeline scanner to insert the GitHub Actions YAML file. repo/workflow/user permissions required
+2. ox_host_url - insert your self-hosted OX server URL to allow the scanner to connect to your OX instance.
+3. [optionally] - if running self-hosted GitHub, supply a `--github-api` argument so that the action connects properly to your GH instance.
 
 For additional options, please refer to this link: https://github.com/oxsecurity/ox-security-scan, if you decide to make changes to the YAML file contents.
+
+## Usage
+
+GitHub SaaS:
+`python main.py`
+
+Self-hosted GitHub:
+`python main.py --github-api "gh-server.mycompany.com"`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.31.0
+requests==2.32.3


### PR DESCRIPTION
Adds optional CLI arg `--github-api` to allow for non-default `api.github.com` values for those who self-host GitHub.

Added some additional output for clarity.

Updated requests library per OX recommendation.